### PR TITLE
fix: point docs nav to account recovery

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ import zkEmailLogo from "../assets/ZKEmailLogo.svg";
 
 const NAV_LINKS = [
   { link: "https://prove.email/blog", title: "Blog" },
-  { link: "https://docs.zk.email", title: "Docs" },
+  { link: "https://docs.zk.email/account-recovery/", title: "Docs" },
   { link: "https://prove.email/", title: "Demos" },
   { link: "https://t.me/zkemail", title: "Contact" },
 ];


### PR DESCRIPTION
This points the recovery site's Docs nav item at the Account Recovery docs section instead of the docs homepage. The changed surface is intentionally limited to the shared navbar link used by both desktop and mobile navigation.

| Area | Change | Evidence |
| --- | --- | --- |
| Navbar Docs link | `https://docs.zk.email` -> `https://docs.zk.email/account-recovery/` | Target URL returns HTTP 200. |
| App build | No routing or UI structure changes beyond the link target. | `yarn build` completed successfully. |

Validation run locally:

```text
npx --yes yarn@1.22.22 build
vite build completed successfully

npx --yes yarn@1.22.22 lint
eslint completed with no warnings

git diff --check
clean
```

Fixes zkemail/email-recovery#104.